### PR TITLE
refactor: Moved tool requirements into their own file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,1 @@
-gladier_tools
-matplotlib
-globus-pilot
-numpy
-h5py
+gladier_tools>=0.3.0

--- a/tool-requirements.txt
+++ b/tool-requirements.txt
@@ -1,0 +1,4 @@
+matplotlib
+globus-pilot
+numpy
+h5py


### PR DESCRIPTION
Tool requirements are only needed on the funcx endpoint or container
They are not needed on the Gladier client that deploys the flow.