### PR TITLE
chore: Move default filters in search views to app.py as setting

### DIFF
--- a/xpcs_portal/xpcs_index/apps.py
+++ b/xpcs_portal/xpcs_index/apps.py
@@ -26,6 +26,13 @@ SEARCH_INDEXES = {
         'tabbed_project': False,
         'access': 'private',
         'template_override_dir': 'xpcs',
+        # Automatically append these filters to all searches
+        # Currently, this is used to hide a globus-pilot record used for tracking project data
+        'default_filters': [{
+            'type': 'match_all',
+            'field_name': 'project_metadata.project-slug',
+            'values': ['xpcs-8id']
+        }],
         'description': (
             'X-ray Photon Correlation Spectroscopy (XPCS) is a technique to '
             'study dynamics in materials at nanoscale by identifying '

--- a/xpcs_portal/xpcs_index/views.py
+++ b/xpcs_portal/xpcs_index/views.py
@@ -24,12 +24,7 @@ class XPCSSearchView(LoginRequiredMixin, SearchView):
 
     @property
     def filters(self):
-        project_filters = [{
-            'type': 'match_all',
-            'field_name': 'project_metadata.project-slug',
-            'values': ['xpcs-8id']
-        }]
-        return super().filters + project_filters
+        return super().filters + self.get_index_info().get('default_filters', [])
 
 
 class XPCSDetailView(DetailView):


### PR DESCRIPTION
Previously, a hard-coded filter was set on all xpcs search requests.
This makes that setting configurable.

@tskluzac Does this make sense for your project? 