### PR TITLE
Rename 'WarmNodes' to 'AquireNodes'. Add to Online Processing.

### DIFF
--- a/gladier_xpcs/flow_online.py
+++ b/gladier_xpcs/flow_online.py
@@ -25,6 +25,7 @@ class XPCSOnlineFlow(GladierBaseClient):
     gladier_tools = [
         'gladier_xpcs.tools.TransferFromClutchToTheta',
         'gladier_xpcs.tools.PrePublish',
+        'gladier_xpcs.tools.AcquireNodes',
         'gladier_xpcs.tools.EigenCorr',
         # 'gladier_xpcs.tools.transfer_from_clutch_to_theta.TransferToClutch',
         'gladier_xpcs.tools.MakeCorrPlots',

--- a/gladier_xpcs/flow_reprocess.py
+++ b/gladier_xpcs/flow_reprocess.py
@@ -27,7 +27,7 @@ class XPCSReprocessingFlow(GladierBaseClient):
         'gladier_xpcs.reprocessing_tools.transfer_qmap.TransferQmap',
         # Apply custom hdf settings to pass info into corr
         'gladier_xpcs.reprocessing_tools.apply_qmap.ApplyQmap',
-        'gladier_xpcs.tools.WarmNodes',
+        'gladier_xpcs.tools.AcquireNodes',
         'gladier_xpcs.tools.EigenCorr',
         'gladier_xpcs.tools.MakeCorrPlots',
 

--- a/gladier_xpcs/tools/__init__.py
+++ b/gladier_xpcs/tools/__init__.py
@@ -4,7 +4,7 @@ from .corr import EigenCorr
 from .plot import MakeCorrPlots
 from .gather_xpcs_metadata import GatherXPCSMetadata
 from .publish import Publish
-from .warm_nodes import WarmNodes
+from .acquire_nodes import AcquireNodes
 
 
 
@@ -15,5 +15,5 @@ __all__ = [
     'MakeCorrPlots',
     'GatherXPCSMetadata',
     'Publish',
-    'WarmNodes',
+    'AcquireNodes',
     ]

--- a/gladier_xpcs/tools/acquire_nodes.py
+++ b/gladier_xpcs/tools/acquire_nodes.py
@@ -1,16 +1,16 @@
 from gladier import GladierBaseTool, generate_flow_definition
 
 
-def warm_nodes(**data):
-    return 'Nodes are warm and toasty'
+def acquire_nodes(**data):
+    return 'Compute nodes have been acquired.'
 
 
 @generate_flow_definition(modifiers={
-    warm_nodes: {'WaitTime': 86400}  # Wait 1 day for free nodes
+    acquire_nodes: {'WaitTime': 86400}  # Wait 1 day for free nodes
 })
-class WarmNodes(GladierBaseTool):
-    """Warm Nodes specifically does nothing, and is intended to be run before
+class AcquireNodes(GladierBaseTool):
+    """Acquire Nodes specifically does nothing, and is intended to be run before
     other compute tasks to ensure compute nodes are ready. This solves the problem
     of actual compute tasks timing out waiting for a node to spin up."""
-    funcx_functions = [warm_nodes]
+    funcx_functions = [acquire_nodes]
     required_input = ['funcx_endpoint_compute']


### PR DESCRIPTION
Having the AcquireNodes step will ensure we don't have timeouts
due to not being able to acquire nodes on the corr task.