### PR TITLE
Temporarily disable Transfer To Clutch tool.

### DIFF
--- a/gladier_xpcs/flow_online.py
+++ b/gladier_xpcs/flow_online.py
@@ -27,7 +27,6 @@ class XPCSOnlineFlow(GladierBaseClient):
         'gladier_xpcs.tools.PrePublish',
         'gladier_xpcs.tools.AcquireNodes',
         'gladier_xpcs.tools.EigenCorr',
-        'gladier_xpcs.tools.transfer_to_clutch.TransferToClutch',
         'gladier_xpcs.tools.MakeCorrPlots',
         'gladier_xpcs.tools.gather_xpcs_metadata.GatherXPCSMetadata',
         'gladier_xpcs.tools.Publish',


### PR DESCRIPTION
This tool requires special write permissions on Clutch, which I don't have. Disabling it for now so it doesn't cause runs to stall. 