### PR TITLE
Migrate to eagle endpoint

### DIFF
--- a/xpcs_portal/testing/settings.py
+++ b/xpcs_portal/testing/settings.py
@@ -104,16 +104,13 @@ SOCIAL_AUTH_GLOBUS_SCOPE = [
     'urn:globus:auth:scope:search.api.globus.org:all',
     'urn:globus:auth:scope:transfer.api.globus.org:all',
     'urn:globus:auth:scope:groups.api.globus.org:view_my_groups_and_memberships',  # noqa
-    # General Petrel HTTPS scope used for previewing images and file content
-    'https://auth.globus.org/scopes/56ceac29-e98a-440a-a594-b41e7a084b62/all',
-    # Temporary scope for https on kanzus data,
-    'https://auth.globus.org/scopes/c7683485-3c3f-454a-94c0-74310c80b32a/https',  # noqa
+    # Scope for xpcs HTTPS data on an Eagle Shared Endpoint.
+    'https://auth.globus.org/scopes/74defd5b-5f61-42fc-bcc4-834c9f376a4f/https',  # noqa
     # Note: Automate scopes are only added if the globus-automate-client is installed
 ] + extra_scopes
 
 ALLOWED_FRONTEND_TOKENS = [
-    'petrel_https_server',
-    'c7683485-3c3f-454a-94c0-74310c80b32a',
+    '74defd5b-5f61-42fc-bcc4-834c9f376a4f',
 ]
 
 

--- a/xpcs_portal/xpcs_index/apps.py
+++ b/xpcs_portal/xpcs_index/apps.py
@@ -12,7 +12,7 @@ class XPCSIndexConfig(AppConfig):
 
 
 GLADIER_CFG = os.path.abspath(os.path.join(APP_DIR, 'gladier.cfg'))
-RESOURCE_SERVER = 'petrel_https_server'
+RESOURCE_SERVER = '74defd5b-5f61-42fc-bcc4-834c9f376a4f'
 # RESOURCE_SERVER = 'c7683485-3c3f-454a-94c0-74310c80b32a'
 REPROCESSING_FLOW_DEPLOYMENT = NickPortalDeployment()
 

--- a/xpcs_portal/xpcs_index/fields.py
+++ b/xpcs_portal/xpcs_index/fields.py
@@ -283,20 +283,14 @@ def filename(result):
 def https_url(result):
     rfm = get_file(result)
     if rfm and rfm.get('url'):
-        gurl = urlsplit(rfm.get('url'))
-        return urlunsplit(
-            ('https',
-             'e55b4eab-6d04-11e5-ba46-22000b92c6ec.e.globus.org',
-             gurl.path,
-             '', '')
-            )
+        return rfm['url']
 
 
 def globus_app_link(result):
     rfm = get_file(result)
     if rfm and rfm.get('url'):
         gurl = urlsplit(os.path.dirname(rfm.get('url')))
-        query_params = {'origin_id': gurl.netloc.replace('.e.globus.org', ''),
+        query_params = {'origin_id': '74defd5b-5f61-42fc-bcc4-834c9f376a4f',
                         'origin_path': gurl.path}
         return urlunsplit(('https', 'app.globus.org', 'file-manager',
                            urlencode(query_params), ''))


### PR DESCRIPTION
This simply removes the references to petrel and trusts the records instead, which are all now set to records on eagle. 