### PR TITLE
Refactor clients, fix retry on non-transient error codes (like 404)

### DIFF
--- a/gladier_xpcs/flow_base.py
+++ b/gladier_xpcs/flow_base.py
@@ -1,0 +1,47 @@
+import logging
+import time
+import random
+import globus_sdk
+from gladier import GladierBaseClient, utils
+# import gladier_xpcs.log  # Uncomment for debug logging
+
+log = logging.getLogger(__name__)
+
+
+class XPCSBaseClient(GladierBaseClient):
+
+    def register_funcx_function(self, function):
+        """Register containers for any functions listed in self.containers"""
+        fxid_name = utils.name_generation.get_funcx_function_name(function)
+        if fxid_name in self.containers.keys():
+            container = self.containers[fxid_name]
+            log.info(f'Registering {fxid_name} with {container["location"]}')
+            fxid_name = utils.name_generation.get_funcx_function_name(function)
+            fxck_name = utils.name_generation.get_funcx_function_checksum_name(function)
+            cfg = self.get_cfg(private=True)
+            cid = self.funcx_client.register_container(**container)
+            fxid = self.funcx_client.register_function(function, function.__doc__, container_uuid=cid)
+            cfg[self.section][fxid_name] = fxid
+            cfg[self.section][fxck_name] = self.get_funcx_function_checksum(function)
+            cfg.save()
+        else:
+            super().register_funcx_function(function)
+
+    def retry_backoff(self, method, *args, **kwargs):
+        retries = 0
+        while retries < self.max_retries:
+            try:
+                return method(*args, **kwargs)
+            except globus_sdk.GlobusTimeoutError:
+                time.sleep(random.randint(1, 10))
+            except globus_sdk.GlobusAPIError as gapie:
+                if gapie.http_status == 400:
+                    raise
+                time.sleep(random.randint(1, 10))
+        raise
+
+    def run_flow(self, *args, **kwargs):
+        return self.retry_backoff(super().run_flow, *args, **kwargs)
+
+    def get_status(self, *args, **kwargs):
+        return self.retry_backoff(super().get_status, *args, **kwargs)

--- a/gladier_xpcs/flow_base.py
+++ b/gladier_xpcs/flow_base.py
@@ -9,6 +9,12 @@ log = logging.getLogger(__name__)
 
 
 class XPCSBaseClient(GladierBaseClient):
+    # Allow all admins of the XPCS developers group to deploy/run flows
+    globus_group = '368beb47-c9c5-11e9-b455-0efb3ba9a670'
+    # This is a bit of a hack while we wait for Globus SDK v3, after that
+    # it should automaically retry on these codes
+    TRANSIENT_ERROR_STATUS_CODES = (429, 500, 502, 503, 504)
+    max_retries = 10
 
     def register_funcx_function(self, function):
         """Register containers for any functions listed in self.containers"""
@@ -35,7 +41,7 @@ class XPCSBaseClient(GladierBaseClient):
             except globus_sdk.GlobusTimeoutError:
                 time.sleep(random.randint(1, 10))
             except globus_sdk.GlobusAPIError as gapie:
-                if gapie.http_status == 400:
+                if gapie.http_status not in self.TRANSIENT_ERROR_STATUS_CODES:
                     raise
                 time.sleep(random.randint(1, 10))
         raise

--- a/gladier_xpcs/flow_gpu.py
+++ b/gladier_xpcs/flow_gpu.py
@@ -7,8 +7,6 @@ from gladier_xpcs.flow_base import XPCSBaseClient
    'publish_gather_metadata': {'payload': '$.GatherXpcsMetadata.details.result[0]'}
 })
 class XPCSGPUFlow(XPCSBaseClient):
-    globus_group = '368beb47-c9c5-11e9-b455-0efb3ba9a670'
-    max_retries = 10
     # See flow_base.py for assigning containers.
     containers = {}
 

--- a/gladier_xpcs/flow_online.py
+++ b/gladier_xpcs/flow_online.py
@@ -8,8 +8,6 @@ from gladier_xpcs.tools.corr import eigen_corr
     'publish_gather_metadata': {'payload': '$.GatherXpcsMetadata.details.result[0]'}
 })
 class XPCSOnlineFlow(XPCSBaseClient):
-    globus_group = '368beb47-c9c5-11e9-b455-0efb3ba9a670'
-    max_retries = 10
     containers = {
         utils.name_generation.get_funcx_function_name(eigen_corr): {
             'container_type': 'singularity',

--- a/gladier_xpcs/flow_online.py
+++ b/gladier_xpcs/flow_online.py
@@ -1,18 +1,13 @@
-import logging
-import time
-import random
-import globus_sdk
-from gladier import GladierBaseClient, generate_flow_definition, utils
+from gladier import generate_flow_definition, utils
+from gladier_xpcs.flow_base import XPCSBaseClient
 from gladier_xpcs.tools.corr import eigen_corr
 # import gladier_xpcs.log  # Uncomment for debug logging
-
-log = logging.getLogger(__name__)
 
 
 @generate_flow_definition(modifiers={
     'publish_gather_metadata': {'payload': '$.GatherXpcsMetadata.details.result[0]'}
 })
-class XPCSOnlineFlow(GladierBaseClient):
+class XPCSOnlineFlow(XPCSBaseClient):
     globus_group = '368beb47-c9c5-11e9-b455-0efb3ba9a670'
     max_retries = 10
     containers = {
@@ -31,39 +26,3 @@ class XPCSOnlineFlow(GladierBaseClient):
         'gladier_xpcs.tools.gather_xpcs_metadata.GatherXPCSMetadata',
         'gladier_xpcs.tools.Publish',
     ]
-
-    def register_funcx_function(self, function):
-        """Register containers for any functions listed in self.containers"""
-        fxid_name = utils.name_generation.get_funcx_function_name(function)
-        if fxid_name in self.containers.keys():
-            container = self.containers[fxid_name]
-            log.info(f'Registering {fxid_name} with {container["location"]}')
-            fxid_name = utils.name_generation.get_funcx_function_name(function)
-            fxck_name = utils.name_generation.get_funcx_function_checksum_name(function)
-            cfg = self.get_cfg(private=True)
-            cid = self.funcx_client.register_container(**container)
-            fxid = self.funcx_client.register_function(function, function.__doc__, container_uuid=cid)
-            cfg[self.section][fxid_name] = fxid
-            cfg[self.section][fxck_name] = self.get_funcx_function_checksum(function)
-            cfg.save()
-        else:
-            super().register_funcx_function(function)
-
-    def retry_backoff(self, method, *args, **kwargs):
-        retries = 0
-        while retries < self.max_retries:
-            try:
-                return method(*args, **kwargs)
-            except globus_sdk.GlobusTimeoutError:
-                time.sleep(random.randint(1, 10))
-            except globus_sdk.GlobusAPIError as gapie:
-                if gapie.http_status == 400:
-                    raise
-                time.sleep(random.randint(1, 10))
-        raise
-
-    def run_flow(self, *args, **kwargs):
-        return self.retry_backoff(super().run_flow, *args, **kwargs)
-
-    def get_status(self, *args, **kwargs):
-        return self.retry_backoff(super().get_status, *args, **kwargs)


### PR DESCRIPTION
A bit of refactoring to remove duplicated code between the online/gpu flows. The combine base client contains the fix for not doing retries on 404.