### PR TITLE
feat: Switch GPU flow to prod index, add metadata to track corr_gpu tooling

### DIFF
--- a/scripts/xpcs_corr_gpu_client.py
+++ b/scripts/xpcs_corr_gpu_client.py
@@ -64,14 +64,16 @@ if __name__ == '__main__':
                 # This is the directory which will be published
                 'dataset': dataset_dir,
                 # Old index, switch back to this when we want to publish to the main index
-                # 'index': '6871e83e-866b-41bc-8430-e3cf83b43bdc',
+                'index': '6871e83e-866b-41bc-8430-e3cf83b43bdc',
                 # Test Index, use this for testing
-                'index': '2e72452f-e932-4da0-b43c-1c722716896e',
+                # 'index': '2e72452f-e932-4da0-b43c-1c722716896e',
                 'project': 'xpcs-8id',
                 'source_globus_endpoint': depl_input['input']['globus_endpoint_proc'],
                 # Extra groups can be specified here. The XPCS Admins group will always
                 # be provided automatically.
                 'groups': [args.group] if args.group else [],
+                'metadata': {'executable_name': 'corr_gpu',
+                             'executable_version': 'prototype'}
             },
 
             'transfer_from_clutch_to_theta_items': [


### PR DESCRIPTION
@banubot Merging these now, but I want to note them for you here. The index change from test to prod is below, I added a couple extra pieces of metadata to track tooling. 

Not included in these changes were the workers per-node, which I set to 1 in my funcx config. 