### PR TITLE
Attempted plotting fixes

### DIFF
--- a/gladier_xpcs/tools/plot.py
+++ b/gladier_xpcs/tools/plot.py
@@ -1,3 +1,5 @@
+import pathlib
+import sys
 from gladier import GladierBaseTool, generate_flow_definition
 
 
@@ -312,3 +314,14 @@ class MakeCorrPlots(GladierBaseTool):
     funcx_functions = [
         make_corr_plots
     ]
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 2:
+        print('Usage: python plot.py my_file.hdf')
+    input_file = pathlib.Path(sys.argv[1]).absolute()
+    # Create the 'expected' processing directory, which should look like this:
+    # * Top level proc_dir/
+    #     * HDF_Folder/
+    #         * HDF_File.hdf
+    make_corr_plots(proc_dir=str(input_file.parent.parent), hdf_file=str(input_file))

--- a/gladier_xpcs/tools/plot.py
+++ b/gladier_xpcs/tools/plot.py
@@ -152,7 +152,7 @@ def make_corr_plots(**data):
                     g_index += 1
                     if g_index == n_plots:
                         sfig(basename, g_start, g_index - 1)
-                        break
+                        return
             sfig(basename, g_start, g_index - 1)
 
     def plot_g2_all_fit(xpcs_h5file):
@@ -189,7 +189,7 @@ def make_corr_plots(**data):
                     g_index += 1
                     if g_index == n_plots:
                         sfig(basename, g_start, g_index - 1)
-                        break
+                        return
             sfig(basename, g_start, g_index - 1)
 
     def plot_fits(xpcs_h5file):


### PR DESCRIPTION
There are a few problems with the current plotting script, mainly: 

* The current error reporting doesn't do a great job of telling us what went wrong
* Multiple errors will overwrite one another

The fixes here attempt to log everything to a file in a neat cohesive way, but that had its own problems too. Logging from the earlier corr step conflicts with logging here, such that the corr logging picks up on the plot logging and results in double logging output. Here's the **corr** log after a successful run: 

```
INFO:root:Logging setup with level INFO
WARNING:boost_corr.xpcs_aps_8idi.xpcs_qpartitionmap:qmap inconsistent at sq: 346 <-> [69 70]: dq
INFO:make_corr_plots:Logging setup with level DEBUG
INFO:make_corr_plots:Plotting plot_intensity_vs_time...
INFO:make_corr_plots:Plotting plot_intensity_vs_q...
INFO:make_corr_plots:Plotting plot_intensity_t_vs_q...
INFO:make_corr_plots:Plotting plot_g2_all...
INFO:make_corr_plots:Plotting plot_g2_all_fit...
ERROR:make_corr_plots:plot_g2_all_fit: Missing data needed for plot: "Unable to open object (object 'g2avgFIT1' doesn't exist)"
INFO:make_corr_plots:Plotting plot_pixelSum...
INFO:make_corr_plots:Plotting plot_fits...
ERROR:make_corr_plots:plot_fits: Missing data needed for plot: "Unable to open object (object 'contrastFIT1' doesn't exist)"
```

This is the **corr** log, not the plotting log. They're both smooshed together!

You can also see the same thing here (for a while at least, until we overwrite it): https://acdc.alcf.anl.gov/xpcs/detail/globus%253A%252F%252F74defd5b-5f61-42fc-bcc4-834c9f376a4f%252FXPCSDATA%252FAutomate%252FA001_Aerogel_1mm_att6_Lq0_001_0001-1000/

I'm not quite sure how we do logging that doesn't interfere with other modules. Perhaps we need to setup custom loggers for all funcx functions that need to do it?