### PR TITLE
fix: Logging on boost_corr step to overwrite logs on each run

### DIFF
--- a/gladier_xpcs/tools/xpcs_boost_corr.py
+++ b/gladier_xpcs/tools/xpcs_boost_corr.py
@@ -11,7 +11,7 @@ def xpcs_boost_corr(**data):
     log_file = os.path.join(data['proc_dir'], 'boost_corr.log')
     handlers = (
         # Useful for flows, logging will be captured in a file
-        logging.FileHandler(filename=log_file),
+        logging.FileHandler(filename=log_file, mode='w'),
         # Useful for testing, will only output when run directly on compute
         logging.StreamHandler(),
     )


### PR DESCRIPTION
Previously, logs would be appended run-over-run, causing logs
to become large and hard to read.