### PR TITLE
Switch my deployment and default datasets to pull from Eagle instead of Clutch

### DIFF
--- a/gladier_xpcs/deployments.py
+++ b/gladier_xpcs/deployments.py
@@ -36,8 +36,8 @@ class NickTheta(BaseDeployment):
     """Nicks deployment on theta"""
 
     globus_endpoints = {
-        # Clutch DMZ
-        'globus_endpoint_source': 'fdc7e74a-fa78-11e8-9342-0e3d676669f4',
+        # Eagle -- XPCS Data 8-ID APS
+        'globus_endpoint_source': '74defd5b-5f61-42fc-bcc4-834c9f376a4f',
         'globus_endpoint_proc': '08925f04-569f-11e7-bef8-22000b9a448b',
     }
 

--- a/scripts/xpcs_online_boost_client.py
+++ b/scripts/xpcs_online_boost_client.py
@@ -17,13 +17,13 @@ def arg_parse():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--hdf', help='Path to the hdf (metadata) file',
-                        default='/data/xpcs8/2019-1/comm201901/cluster_results/'
+                        default='/XPCSDATA/2019-1/comm201901/cluster_results/'
                                 'A001_Aerogel_1mm_att6_Lq0_001_0001-1000.hdf')
     parser.add_argument('--raw', help='Path to the raw data file. Multiple formats (.imm, .bin, etc) supported',
-                        default='/data/xpcs8/2019-1/comm201901/A001_Aerogel_1mm_att6_Lq0_001'
+                        default='/XPCSDATA/2019-1/comm201901/A001_Aerogel_1mm_att6_Lq0_001'
                                 '/A001_Aerogel_1mm_att6_Lq0_001_00001-01000.imm')
     parser.add_argument('--qmap', help='Path to the qmap file',
-                        default='/data/xpcs8/partitionMapLibrary/2019-1/comm201901_qmap_aerogel_Lq0.h5')
+                        default='/XPCSDATA/partitionMapLibrary/2019-1/comm201901_qmap_aerogel_Lq0.h5')
     parser.add_argument('--atype', default='Both', help='Analysis type to be performed. Available: Multitau, Twotime')
     parser.add_argument('--gpu_flag', type=int, default=0, help='''Choose which GPU to use. if the input is -1, then CPU is used''')
     # Group MUST not be None in order for PublishTransferSetPermission to succeed. Group MAY


### PR DESCRIPTION
This is the "easy" fix for switching to Eagle. The transfer is still applicable for moving this to a writable location for processing. I've had trouble getting direct processing working on an Eagle location where I'm not explicitly added to the group. 