### PR TITLE
feat: Abstract collections to make path information routable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,87 @@ cd scripts/
 python xpcs_reproc_client.py
 ```
 
+### ALCF Configuration
+
+Hopefully, this document is a little outdated and you're executing on Polaris!
+Please add, update, or correct information as things change. 
+
+## Environment Setup
+
+```
+  conda create -n gladier-xpcs
+  conda activate gladier-xpcs
+
+  # Used for running Boost Corr
+  conda install pytorch==1.12.1 cudatoolkit=11.6 -c pytorch -c conda-forge
+  pip install -e git+https://github.com/AZjk/boost_corr#egg=boost_corr
+
+  # Used for managing compute nodes
+  pip install funcx-endpoint
+```
+
+### Example Config
+
+```
+~/.funcx/theta/config.py
+
+from parsl.addresses import address_by_hostname
+from parsl.launchers import AprunLauncher
+from parsl.providers import CobaltProvider
+
+from funcx_endpoint.endpoint.utils.config import Config
+from funcx_endpoint.executors import HighThroughputExecutor
+from funcx_endpoint.strategies import SimpleStrategy
+
+# PLEASE UPDATE user_opts BEFORE USE
+user_opts = {
+    'theta': {
+        # Add your config here.
+        'worker_init': 'source activate funcx',
+        'scheduler_options': '',
+        # Specify the account/allocation to which jobs should be charged
+    }
+}
+
+
+config = Config(
+    executors=[
+        HighThroughputExecutor(
+            heartbeat_period=15,
+            heartbeat_threshold=120,
+            address=address_by_hostname(),
+            scheduler_mode='soft',
+
+            # Set these for using containers
+            worker_mode='singularity_reuse',
+            container_type='singularity',
+            container_cmd_options='-H /home/$USER --bind /eagle/APSDataAnalysis --bind /projects/APSDataAnalysis/',
+            provider=CobaltProvider(
+                # These may change depending on your allocation
+                account='APSDataAnalysis',
+                queue='analysis',
+                # string to prepend to #COBALT blocks in the submit
+                # script to the scheduler eg: '#COBALT -t 50'
+                scheduler_options=user_opts['theta']['scheduler_options'],
+                # Command to be run before starting a worker, such as:
+                # 'module load Anaconda; source activate funcx_env'.
+                worker_init=user_opts['theta']['worker_init'],
+                launcher=AprunLauncher(overrides="-d 64"),
+                # Increase this if tasks consistently. outpace available nodes. 
+                nodes_per_block=2,
+                init_blocks=1,
+                min_blocks=0,
+                max_blocks=60,
+                cmd_timeout=300,
+                # 1 hour tends to be a good middleground -- short enough theta
+                # usually starts nodes quickly, long enough for (at least lambda)
+                # jobs to complete. NOTE: funcx==0.3.3 will not restart tasks that
+                # die due to walltime.
+                walltime='1:00:00',
+            ),
+            strategy=SimpleStrategy(max_idletime=900),
+            max_workers_per_node=16,
+            )
+        ]
+    )
+```

--- a/gladier_xpcs/collections.py
+++ b/gladier_xpcs/collections.py
@@ -1,0 +1,31 @@
+import pathlib
+
+
+class SharedCollection:
+
+    def __init__(self, uuid, path, name=None):
+        self.path = pathlib.Path(path)
+        self.uuid = uuid
+        self.name = name or self.__class__.__name__
+
+    def to_posix(self, shared_globus_path:str):
+        assert shared_globus_path.startswith('/'), 'Paths must start at the root share path "/"'
+        return self.path / shared_globus_path
+
+    def to_globus(self, posix_path):
+        """Takes a full posix path and returns the path to the same location
+        relative to the Globus Collection Share Path.
+
+        For example, if the Globus Collection has a share path of /share/solar_data/
+
+        And the path given is /share/solar_data/orbits/pass1.tar.gz
+
+        The result will be:
+
+        /orbits/pass1.tar.gz
+
+        Where /orbits/pass1.tar.gz is the root path to the file when viewed through
+        the Globus Shared Collection.
+        """
+        path = pathlib.PosixPath(posix_path)
+        return f'/{str(path.relative_to(self.path))}'

--- a/gladier_xpcs/flows/flow_boost.py
+++ b/gladier_xpcs/flows/flow_boost.py
@@ -26,5 +26,5 @@ class XPCSBoost(GladierBaseClient):
         'gladier_xpcs.tools.BoostCorr',
         'gladier_xpcs.tools.MakeCorrPlots',
         'gladier_xpcs.tools.gather_xpcs_metadata.GatherXPCSMetadata',
-        'gladier_xpcs.tools.Publish',
+        'gladier_tools.publish.Publish',
     ]

--- a/gladier_xpcs/flows/flow_boost.py
+++ b/gladier_xpcs/flows/flow_boost.py
@@ -21,7 +21,7 @@ from gladier_xpcs.flows.container_flow_base import ContainerBaseClient
 class XPCSBoost(GladierBaseClient):
     globus_group = '368beb47-c9c5-11e9-b455-0efb3ba9a670'
     gladier_tools = [
-        'gladier_xpcs.tools.TransferFromClutchToTheta',
+        'gladier_xpcs.tools.SourceTransfer',
         'gladier_xpcs.tools.AcquireNodes',
         'gladier_xpcs.tools.BoostCorr',
         'gladier_xpcs.tools.MakeCorrPlots',

--- a/gladier_xpcs/tools/__init__.py
+++ b/gladier_xpcs/tools/__init__.py
@@ -1,5 +1,6 @@
 from .transfer_from_clutch_to_theta import TransferFromClutchToTheta
 from .pre_publish import PrePublish
+from .source_transfer import SourceTransfer
 
 from .eigen_corr import EigenCorr
 from .xpcs_boost_corr import BoostCorr
@@ -13,6 +14,7 @@ from .acquire_nodes import AcquireNodes
 
 __all__ = [
     'TransferFromClutchToTheta',
+    'SourceTransfer',
     'PrePublish',
     'EigenCorr',
     'BoostCorr',

--- a/gladier_xpcs/tools/source_transfer.py
+++ b/gladier_xpcs/tools/source_transfer.py
@@ -1,0 +1,28 @@
+from gladier import GladierBaseTool
+
+
+class SourceTransfer(GladierBaseTool):
+
+    flow_definition = {
+        'Comment': 'Transfer a file or directory in Globus',
+        'StartAt': 'SourceTransfer',
+        'States': {
+            'SourceTransfer': {
+                'Comment': 'Transfer from the source collection to the staging location',
+                'Type': 'Action',
+                'ActionUrl': 'https://actions.automate.globus.org/transfer/transfer',
+                'Parameters': {
+                    'source_endpoint_id.$': '$.input.source_transfer.source_endpoint_id',
+                    'destination_endpoint_id.$': '$.input.source_transfer.destination_endpoint_id',
+                    'transfer_items.$': '$.input.source_transfer.transfer_items',
+                },
+                'ResultPath': '$.SourceTransfer',
+                'WaitTime': 1800,
+                'End': True
+            },
+        }
+    }
+
+    required_input = [
+        'source_transfer'
+    ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gladier
+gladier==0.7.1
 gladier_tools

--- a/scripts/xpcs_online_boost_client.py
+++ b/scripts/xpcs_online_boost_client.py
@@ -100,6 +100,7 @@ if __name__ == '__main__':
                 # 'index': '2e72452f-e932-4da0-b43c-1c722716896e',
                 'project': 'xpcs-8id',
                 'source_globus_endpoint': depl_input['input']['globus_endpoint_proc'],
+                'source_collection_basepath': str(deployment.staging_collection.path),
                 # Extra groups can be specified here. The XPCS Admins group will always
                 # be provided automatically.
                 'groups': [args.group] if args.group else [],

--- a/scripts/xpcs_online_boost_client.py
+++ b/scripts/xpcs_online_boost_client.py
@@ -17,13 +17,13 @@ def arg_parse():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--hdf', help='Path to the hdf (metadata) file',
-                        default='/XPCSDATA/2019-1/comm201901/cluster_results/'
+                        default='/eagle/XPCS-DATA-DYS/XPCSDATA/2019-1/comm201901/cluster_results/'
                                 'A001_Aerogel_1mm_att6_Lq0_001_0001-1000.hdf')
     parser.add_argument('--raw', help='Path to the raw data file. Multiple formats (.imm, .bin, etc) supported',
-                        default='/XPCSDATA/2019-1/comm201901/A001_Aerogel_1mm_att6_Lq0_001'
+                        default='/eagle/XPCS-DATA-DYS/XPCSDATA/2019-1/comm201901/A001_Aerogel_1mm_att6_Lq0_001'
                                 '/A001_Aerogel_1mm_att6_Lq0_001_00001-01000.imm')
     parser.add_argument('--qmap', help='Path to the qmap file',
-                        default='/XPCSDATA/partitionMapLibrary/2019-1/comm201901_qmap_aerogel_Lq0.h5')
+                        default='/eagle/XPCS-DATA-DYS/XPCSDATA/partitionMapLibrary/2019-1/comm201901_qmap_aerogel_Lq0.h5')
     parser.add_argument('--atype', default='Both', help='Analysis type to be performed. Available: Multitau, Twotime')
     parser.add_argument('--gpu_flag', type=int, default=0, help='''Choose which GPU to use. if the input is -1, then CPU is used''')
     # Group MUST not be None in order for PublishTransferSetPermission to succeed. Group MAY
@@ -110,15 +110,15 @@ if __name__ == '__main__':
                 'destination_endpoint_id': deployment.staging_collection.uuid,
                 'transfer_items': [
                     {
-                        'source_path': args.raw,
+                        'source_path': deployment.source_collection.to_globus(args.raw),
                         'destination_path': deployment.staging_collection.to_globus(raw_file),
                     },
                     {
-                        'source_path': args.hdf,
+                        'source_path': deployment.source_collection.to_globus(args.hdf),
                         'destination_path': deployment.staging_collection.to_globus(input_hdf_file),
                     },
                     {
-                        'source_path': args.qmap,
+                        'source_path': deployment.source_collection.to_globus(args.qmap),
                         'destination_path': deployment.staging_collection.to_globus(qmap_file),
                     }
                 ],


### PR DESCRIPTION
This is a first stab at a common pathing problem in flows: POSIX paths map to different locations than Globus Shared Endpoint paths.

Mainly, this introduces the SharedCollection path which tracks the POSIX path associated with a Globus share. Paths can then be 'translated' to either posix or globus paths as needed.