### PR TITLE
fix: Revert 'POSIX' source input paths for 'Globus' paths

### DIFF
--- a/scripts/xpcs_online_boost_client.py
+++ b/scripts/xpcs_online_boost_client.py
@@ -17,13 +17,13 @@ def arg_parse():
     parser = argparse.ArgumentParser()
 
     parser.add_argument('--hdf', help='Path to the hdf (metadata) file',
-                        default='/eagle/XPCS-DATA-DYS/XPCSDATA/2019-1/comm201901/cluster_results/'
+                        default='/XPCSDATA/2019-1/comm201901/cluster_results/'
                                 'A001_Aerogel_1mm_att6_Lq0_001_0001-1000.hdf')
     parser.add_argument('--raw', help='Path to the raw data file. Multiple formats (.imm, .bin, etc) supported',
-                        default='/eagle/XPCS-DATA-DYS/XPCSDATA/2019-1/comm201901/A001_Aerogel_1mm_att6_Lq0_001'
+                        default='/XPCSDATA/2019-1/comm201901/A001_Aerogel_1mm_att6_Lq0_001'
                                 '/A001_Aerogel_1mm_att6_Lq0_001_00001-01000.imm')
     parser.add_argument('--qmap', help='Path to the qmap file',
-                        default='/eagle/XPCS-DATA-DYS/XPCSDATA/partitionMapLibrary/2019-1/comm201901_qmap_aerogel_Lq0.h5')
+                        default='/XPCSDATA/partitionMapLibrary/2019-1/comm201901_qmap_aerogel_Lq0.h5')
     parser.add_argument('--atype', default='Both', help='Analysis type to be performed. Available: Multitau, Twotime')
     parser.add_argument('--gpu_flag', type=int, default=0, help='''Choose which GPU to use. if the input is -1, then CPU is used''')
     # Group MUST not be None in order for PublishTransferSetPermission to succeed. Group MAY
@@ -111,15 +111,15 @@ if __name__ == '__main__':
                 'destination_endpoint_id': deployment.staging_collection.uuid,
                 'transfer_items': [
                     {
-                        'source_path': deployment.source_collection.to_globus(args.raw),
+                        'source_path': args.raw,
                         'destination_path': deployment.staging_collection.to_globus(raw_file),
                     },
                     {
-                        'source_path': deployment.source_collection.to_globus(args.hdf),
+                        'source_path': args.hdf,
                         'destination_path': deployment.staging_collection.to_globus(input_hdf_file),
                     },
                     {
-                        'source_path': deployment.source_collection.to_globus(args.qmap),
+                        'source_path': args.qmap,
                         'destination_path': deployment.staging_collection.to_globus(qmap_file),
                     }
                 ],


### PR DESCRIPTION
The recent change to abstracting paths for guest collections changed the input paths for files to treat them as if they were 'POSIX' paths.

However, DM is setup to start runs with inputs using 'Globus' paths, which broke runs from DM. Reverting to the old style fixes this.