### PR TITLE
Fix xpcs reprocessing tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-gladier>=0.8.0
+gladier>=0.8.1
 gladier_tools

--- a/tests/reprocessing_tools/test_reprocessing.py
+++ b/tests/reprocessing_tools/test_reprocessing.py
@@ -20,7 +20,7 @@ def test_reprocessing_get_xpcs_input(reprocessing_deployment, reprocessing_input
     )
 
 
-@pytest.mark.skip
+# @pytest.mark.skip
 def test_publish_preparation(mock_pathlib, reprocessing_runtime_input):
     from pprint import pprint
     pprint(reprocessing_runtime_input)

--- a/tests/reprocessing_tools/test_reprocessing.py
+++ b/tests/reprocessing_tools/test_reprocessing.py
@@ -1,4 +1,3 @@
-import pytest
 from gladier_xpcs.flows.flow_reprocess import XPCSReprocessingFlow
 from gladier_xpcs.reprocessing_tools.publish_preparation import publish_preparation
 
@@ -20,7 +19,6 @@ def test_reprocessing_get_xpcs_input(reprocessing_deployment, reprocessing_input
     )
 
 
-# @pytest.mark.skip
 def test_publish_preparation(mock_pathlib, reprocessing_runtime_input):
     from pprint import pprint
     pprint(reprocessing_runtime_input)


### PR DESCRIPTION
There was nothing actually wrong with the xpcs tests here, but rather it was a bug in Gladier here: 

https://github.com/globus-gladier/gladier/pull/221

Once that's merged with a 0.8.1 patch release, we can merge this in to fix the unit tests.