### PR TITLE
fix: remote files loading in newly published records

### DIFF
--- a/xpcs_portal/xpcs_index/fields.py
+++ b/xpcs_portal/xpcs_index/fields.py
@@ -199,7 +199,7 @@ def fetch_all_previews(result):
             'caption': get_xpcs_field_title(entry['filename'].rstrip('png'),
                                             ''),
             'name': get_xpcs_field_title(entry['filename'], ''),
-            'url': entry['url'],
+            'url': entry.get('https_url') or entry['url'],
             'filename': entry['filename'],
             'mime_type': entry['mime_type']
         } for entry in result[0].get('files', {})}


### PR DESCRIPTION
This fixes records like the following:

https://acdc.alcf.anl.gov/xpcs/detail/globus%253A%252F%252F74defd5b-5f61-42fc-bcc4-834c9f376a4f%252FXPCSDATA%252FAutomate%252F2024-1%252Fzhang202402_2%252FH001_27445_QZ_XPCS_test-01000/

Which now use publish v2.