### PR TITLE
feat: Automatically determine path for transferring back processed data

### DIFF
--- a/scripts/xpcs_online_boost_client.py
+++ b/scripts/xpcs_online_boost_client.py
@@ -4,6 +4,7 @@
 
 import argparse
 import os
+import sys
 import pathlib
 import time
 
@@ -25,7 +26,7 @@ CLIENT_SECRET = os.getenv("GLADIER_CLIENT_SECRET")
 
 def arg_parse():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--experiment', help='Name of the DM experiment', default='test-xpcs-local-workflow-2023.12.19-01')
+    parser.add_argument('--experiment', help='Name of the DM experiment', default='zhang202402_2')
     parser.add_argument('--hdf', help='Path to the hdf (metadata) file',
                         default='/gdata/dm/8IDI/2024-1/zhang202402_2/data/H001_27445_QZ_XPCS_test-01000/H001_27445_QZ_XPCS_test-01000.hdf')
     parser.add_argument('--raw', help='Path to the raw data file. Multiple formats (.imm, .bin, etc) supported',
@@ -108,7 +109,13 @@ if __name__ == '__main__':
         if source_directory_base.name == 'data':
             source_directory_base = source_directory_base.parent
 
-        result_path_destination_filename = source_directory_base / args.experiment / "analysis" / dataset_name / hdf_name
+        result_path_destination_filename = source_directory_base / "analysis" / dataset_name / hdf_name
+        if source_directory_base.name != args.experiment:
+            print(f'Error: {source_directory_base} does not end with "{args.experiment}" for transferring processed '
+                  'datasets. Please ensure these match to avoid overwriting unexpected files on source (would transfer '
+                  f'output file to the following location "{result_path_destination_filename}).', file=sys.stderr)
+            sys.exit(1)
+
         print(
             f"Flow will transfer processed dataset {hdf_name} back to "
             f"{deployment.source_collection.name} ({deployment.source_collection.uuid}) with path "

--- a/scripts/xpcs_online_boost_client.py
+++ b/scripts/xpcs_online_boost_client.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
 
     if not args.skip_transfer_back:
         # Transfer back step transfers data to the following location automatically:
-        #   /cycle/parent/experiment-name/analysis/dataset-name/dataset.hdf
+        #   /cycle/parent/analysis/dataset-name/dataset.hdf
         # Input dirs tend to look like the following, but the strongest convention we have is that the .hdf file
         # will be within a directory of the same name. It *may* be in a 'data' directory, and if so, we want to
         # make sure processed data does not go back into the 'data' directory. Example paths look like this:


### PR DESCRIPTION
Processed data will automatically be transferred back to source, using the source filenames to determine the paths with some assumptions.

This operation can still be skipped if its test data or if reprocessing data at a later time when write access is no longer allowed on the directory.