### PR TITLE
Batch flow fixes

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v2

--- a/gladier_xpcs/flows/flow_boost_batch.py
+++ b/gladier_xpcs/flows/flow_boost_batch.py
@@ -1,5 +1,4 @@
 from gladier import GladierBaseClient, generate_flow_definition
-import gladier.tests
 
 
 @generate_flow_definition(modifiers={

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-gladier>=0.9.0b4
+gladier>=0.10.0
 gladier_tools
-crispy-bootstrap4==2023.1
+typer


### PR DESCRIPTION
This updates requirements and streamlines the installation process a little. Just for reference, I tested with the following:

```
uv venv --python 3.10 
source .venv/bin/activate
uv pip install -e .
cd scripts
python xpcs_batch_client.py run-experiment-subdirectory /8IDI/2025-2/tempus202507-merge/data/converted/Cb0058_D100_a0011_f2000000 --queue debug --qmap /8IDI/2025-2/tempus202507-merge/data/timepix_Sq90_Dq9_lin.hdf
```

This also uses the latest version of Gladier, v0.10.0. This or the Gladier beta 2 version are required to run batch flows (needed for passing compute args to the compute endpoint).